### PR TITLE
Fix authorization failures when calling service passes an Authorization header

### DIFF
--- a/app/uk.gov.hmrc.helptosaveproxy/connectors/NSIConnector.scala
+++ b/app/uk.gov.hmrc.helptosaveproxy/connectors/NSIConnector.scala
@@ -16,13 +16,12 @@
 
 package uk.gov.hmrc.helptosaveproxy.connectors
 
-import javax.inject.{Inject, Singleton}
-
 import cats.data.EitherT
 import cats.instances.string._
 import cats.syntax.eq._
 import com.codahale.metrics.Timer
 import com.google.inject.ImplementedBy
+import javax.inject.{Inject, Singleton}
 import play.api.http.Status
 import play.api.libs.json.Json
 import uk.gov.hmrc.helptosaveproxy.config.{AppConfig, WSHttpProxy}
@@ -159,7 +158,7 @@ class NSIConnectorImpl @Inject() (auditConnector:    AuditConnector,
 
     val url = s"${appConfig.nsiQueryAccountUrl}/$resource?$queryString"
 
-    EitherT(httpProxy.get(url, Map(nsiAuthHeaderKey → nsiBasicAuth))
+    EitherT(httpProxy.get(url, Map(nsiAuthHeaderKey → nsiBasicAuth))(hc.copy(authorization = None), implicitly[ExecutionContext])
       .map[Either[String, HttpResponse]](Right(_))
       .recover {
         case e ⇒ Left(e.getMessage)

--- a/test/uk/gov/hmrc/helptosaveproxy/connectors/DWPConnectorSpec.scala
+++ b/test/uk/gov/hmrc/helptosaveproxy/connectors/DWPConnectorSpec.scala
@@ -40,9 +40,11 @@ class DWPConnectorSpec extends TestSupport with MockFactory with EitherValues wi
 
   val transactionId = UUID.randomUUID()
 
+  private val headerCarrierWithoutAuthorizationAndToken = argThat[HeaderCarrier](h ⇒ h.authorization.isEmpty && h.token.isEmpty)
+
   def mockGet(url: String)(result: Either[String, HttpResponse]): Unit =
     (mockHTTPProxy.get(_: String, _: Map[String, String])(_: HeaderCarrier, _: ExecutionContext))
-      .expects(url, *, *, *)
+      .expects(url, Map.empty[String, String], headerCarrierWithoutAuthorizationAndToken, *)
       .returning(
         result.fold(
           e ⇒ Future.failed(new Exception(e)),

--- a/test/uk/gov/hmrc/helptosaveproxy/connectors/NSIConnectorSpec.scala
+++ b/test/uk/gov/hmrc/helptosaveproxy/connectors/NSIConnectorSpec.scala
@@ -49,9 +49,11 @@ class NSIConnectorSpec extends TestSupport with MockFactory with GeneratorDriven
   val nsiAuthHeaderKey = appConfig.nsiAuthHeaderKey
   val nsiBasicAuth = appConfig.nsiBasicAuth
 
+  private val headerCarrierWithoutAuthorization = argThat[HeaderCarrier](_.authorization.isEmpty)
+
   def mockPost[I](body: I, url: String)(result: Either[String, HttpResponse]): Unit =
     (mockHTTPProxy.post(_: String, _: I, _: Map[String, String])(_: Writes[I], _: HeaderCarrier, _: ExecutionContext))
-      .expects(url, body, Map(nsiAuthHeaderKey → nsiBasicAuth), *, *, *)
+      .expects(url, body, Map(nsiAuthHeaderKey → nsiBasicAuth), *, headerCarrierWithoutAuthorization, *)
       .returning(
         result.fold(
           e ⇒ Future.failed(new Exception(e)),
@@ -60,7 +62,7 @@ class NSIConnectorSpec extends TestSupport with MockFactory with GeneratorDriven
 
   def mockPut[I](body: I, url: String, needsAuditing: Boolean = true)(result: Either[String, HttpResponse]): Unit =
     (mockHTTPProxy.put(_: String, _: I, _: Boolean, _: Map[String, String])(_: Writes[I], _: HeaderCarrier, _: ExecutionContext))
-      .expects(url, body, needsAuditing, Map(nsiAuthHeaderKey → nsiBasicAuth), *, *, *)
+      .expects(url, body, needsAuditing, Map(nsiAuthHeaderKey → nsiBasicAuth), *, headerCarrierWithoutAuthorization, *)
       .returning(
         result.fold(
           e ⇒ Future.failed(new Exception(e)),
@@ -69,7 +71,7 @@ class NSIConnectorSpec extends TestSupport with MockFactory with GeneratorDriven
 
   def mockGet[I](url: String)(result: Either[String, HttpResponse]): Unit =
     (mockHTTPProxy.get(_: String, _: Map[String, String])(_: HeaderCarrier, _: ExecutionContext))
-      .expects(url, Map(nsiAuthHeaderKey → nsiBasicAuth), *, *)
+      .expects(url, Map(nsiAuthHeaderKey → nsiBasicAuth), headerCarrierWithoutAuthorization, *)
       .returning(
         result.fold(
           e ⇒ Future.failed(new Exception(e)),


### PR DESCRIPTION
The fix is to not passing along the authorization header from the HeaderCarrier, like NSIConnector.createAccount() already does.