### PR TITLE
Revert "HTS-1383: Do not remove internal spaces in roll numbers"

### DIFF
--- a/app/uk.gov.hmrc.helptosaveproxy/models/NSIPayload.scala
+++ b/app/uk.gov.hmrc.helptosaveproxy/models/NSIPayload.scala
@@ -113,7 +113,7 @@ object NSIPayload {
       BankDetails(
         bankDetails.sortCode.cleanupSpecialCharacters.removeAllSpaces.filterNot(allowedSortCodeSeparators.contains).grouped(2).mkString("-"),
         bankDetails.accountNumber.cleanupSpecialCharacters.removeAllSpaces,
-        bankDetails.rollNumber.map(_.cleanupSpecialCharacters),
+        bankDetails.rollNumber.map(_.cleanupSpecialCharacters.removeAllSpaces),
         bankDetails.accountName.trim.cleanupSpecialCharacters
       )
 

--- a/test/uk/gov/hmrc/helptosaveproxy/models/NSIPayloadSpec.scala
+++ b/test/uk/gov/hmrc/helptosaveproxy/models/NSIPayloadSpec.scala
@@ -213,7 +213,7 @@ class NSIPayloadSpec extends WordSpec with Matchers { // scalastyle:off magic.nu
 
         val json: JsValue = Json.toJson(validNSIPayload.copy(nbaDetails = Some(validBankDetails.copy(rollNumber = Some(rollNumber)))))
         val result = json.validate[NSIPayload].get
-        result.nbaDetails.flatMap(_.rollNumber) shouldBe Some("ab cd e 1")
+        result.nbaDetails.flatMap(_.rollNumber) shouldBe Some("abcde1")
       }
 
       "removes leading and trailing whitespaces, new lines, tabs, carriage returns from account names" in {


### PR DESCRIPTION
This reverts commit 288527251423215ec4173faa45341b76a394d89d.