### PR TITLE
DLS-815 Disabled Play CSRF Filter

### DIFF
--- a/conf/application.conf
+++ b/conf/application.conf
@@ -55,6 +55,8 @@ play.modules.enabled += "uk.gov.hmrc.play.bootstrap.MicroserviceModule"
 play.modules.disabled += "play.api.libs.ws.ahc.AhcWSModule"
 play.modules.enabled += "uk.gov.hmrc.helptosaveproxy.http.NewWSModule"
 
+play.filters.disabled += play.filters.csrf.CSRFFilter
+
 httpHeadersWhitelist += ${microservice.correlationIdHeaderName}
 
 # Session Timeout


### PR DESCRIPTION
Integration tests were failing as Play was blocking requests that didn't have a CSRF token. This is a backend service residing in the protected zone, disabling CSRF filter is not a security risk.