### PR TITLE
Dave/dls 5625/lock failed schedule 4

### DIFF
--- a/app/uk.gov.hmrc.helptosaveproxy/auth/Auth.scala
+++ b/app/uk.gov.hmrc.helptosaveproxy/auth/Auth.scala
@@ -24,29 +24,29 @@ import uk.gov.hmrc.play.bootstrap.backend.controller.BackendController
 
 import scala.concurrent.{ExecutionContext, Future}
 
-trait Auth extends AuthorisedFunctions { this: BackendController with Logging ⇒
+trait Auth extends AuthorisedFunctions { this: BackendController with Logging =>
 
   val authProviders: AuthProviders = AuthProviders(GovernmentGateway, PrivilegedApplication)
 
-  type HtsAction = Request[AnyContent] ⇒ Future[Result]
+  type HtsAction = Request[AnyContent] => Future[Result]
 
   def authorised(action: HtsAction)(implicit ec: ExecutionContext): Action[AnyContent] =
-    Action.async { implicit request ⇒
+    Action.async { implicit request =>
       authorised(authProviders) {
         action(request)
       }.recover { handleFailure() }
     }
 
   def handleFailure(): PartialFunction[Throwable, Result] = {
-    case e: NoActiveSession ⇒
+    case e: NoActiveSession =>
       logger.warn(s"no active session was found for user, reason: ${e.reason}")
       Unauthorized
 
-    case e: InternalError ⇒
+    case e: InternalError =>
       logger.warn(s"Could not authenticate user due to internal error: ${e.reason}")
       InternalServerError
 
-    case ex: AuthorisationException ⇒
+    case ex: AuthorisationException =>
       logger.warn(s"could not authenticate user, error: ${ex.reason}")
       Forbidden
   }

--- a/app/uk.gov.hmrc.helptosaveproxy/auth/Auth.scala
+++ b/app/uk.gov.hmrc.helptosaveproxy/auth/Auth.scala
@@ -18,7 +18,7 @@ package uk.gov.hmrc.helptosaveproxy.auth
 
 import play.api.mvc.{Action, AnyContent, Request, Result}
 import uk.gov.hmrc.auth.core.AuthProvider.{GovernmentGateway, PrivilegedApplication}
-import uk.gov.hmrc.auth.core.{AuthProviders, _}
+import uk.gov.hmrc.auth.core._
 import uk.gov.hmrc.helptosaveproxy.util.Logging
 import uk.gov.hmrc.play.bootstrap.backend.controller.BackendController
 

--- a/app/uk.gov.hmrc.helptosaveproxy/config/AppConfig.scala
+++ b/app/uk.gov.hmrc.helptosaveproxy/config/AppConfig.scala
@@ -56,6 +56,8 @@ class AppConfig @Inject()(val runModeConfiguration: Configuration, sc: ServicesC
 
   val dwpBaseUrl: String = sc.baseUrl("dwp")
 
-  val dwpHealthCheckURL: String = s"$dwpBaseUrl/hmrc-healthcheck"
+  val dwpCheckURL: String = s"$dwpBaseUrl/${getString("microservice.services.dwp.check")}"
+
+  val dwpHealthCheckURL: String = s"$dwpBaseUrl/${getString("microservice.services.dwp.health-check")}"
 
 }

--- a/app/uk.gov.hmrc.helptosaveproxy/config/CustomWSConfigParser.scala
+++ b/app/uk.gov.hmrc.helptosaveproxy/config/CustomWSConfigParser.scala
@@ -42,23 +42,23 @@ class CustomWSConfigParser @Inject()(configuration: Configuration, env: Environm
     val internalParser = new WSConfigParser(configuration.underlying, env.classLoader)
     val config = internalParser.parse()
 
-    val keyStores = config.ssl.keyManagerConfig.keyStoreConfigs.filter(_.data.forall(_.nonEmpty)).map { ks ⇒
+    val keyStores = config.ssl.keyManagerConfig.keyStoreConfigs.filter(_.data.forall(_.nonEmpty)).map { ks =>
       (ks.storeType.toUpperCase, ks.filePath, ks.data) match {
-        case (_, None, Some(data)) ⇒
+        case (_, None, Some(data)) =>
           createKeyStoreConfig(ks, data)
 
-        case other ⇒
+        case other =>
           logger.info(s"Adding ${other._1} type keystore")
           ks
       }
     }
 
-    val trustStores = config.ssl.trustManagerConfig.trustStoreConfigs.filter(_.data.forall(_.nonEmpty)).map { ts ⇒
+    val trustStores = config.ssl.trustManagerConfig.trustStoreConfigs.filter(_.data.forall(_.nonEmpty)).map { ts =>
       (ts.filePath, ts.data) match {
-        case (None, Some(data)) ⇒
+        case (None, Some(data)) =>
           createTrustStoreConfig(ts, data)
 
-        case _ ⇒
+        case _ =>
           logger.info(s"Adding ${ts.storeType} type truststore from ${ts.filePath}")
           ts
       }
@@ -82,10 +82,10 @@ class CustomWSConfigParser @Inject()(configuration: Configuration, env: Environm
     val keyStore = initKeystore()
 
     generateCertificates(fileBytes).foreach {
-      case c: X509Certificate ⇒
+      case c: X509Certificate =>
         val alias = c.getSubjectX500Principal.getName
         keyStore.setCertificateEntry(alias, c)
-      case other ⇒
+      case other =>
         logger.warn(s"Expected X509Certificate but got ${other.getType}")
 
     }
@@ -133,7 +133,7 @@ class CustomWSConfigParser @Inject()(configuration: Configuration, env: Environm
       val bytes = base64Decode(data.trim)
       os.write(bytes)
       os.flush()
-      file.getAbsolutePath → bytes
+      file.getAbsolutePath -> bytes
     } finally {
       os.close()
     }

--- a/app/uk.gov.hmrc.helptosaveproxy/connectors/DWPConnector.scala
+++ b/app/uk.gov.hmrc.helptosaveproxy/connectors/DWPConnector.scala
@@ -79,7 +79,7 @@ class DWPConnectorImpl @Inject()(
         .map[Either[String, HttpResponse]] { response ⇒
           val time = timeContext.stop()
           response.status match {
-            case Status.OK ⇒
+            case Status.OK =>
               logger.info(
                 s"ucClaimantCheck returned 200 (OK) with UCDetails: ${response.json}, transactionId: " +
                   s"$transactionId, thresholdAmount: $threshold, ${timeString(time)}",
@@ -87,7 +87,7 @@ class DWPConnectorImpl @Inject()(
                 None
               )
               Right(HttpResponse(200, response.json, Map[String, Seq[String]]())) // scalastyle:ignore magic.number
-            case other ⇒
+            case other =>
               pagerDutyAlerting.alert("Received unexpected http status in response to uc claimant check")
               metrics.dwpClaimantErrorCounter.inc()
               Left(
@@ -96,7 +96,7 @@ class DWPConnectorImpl @Inject()(
           }
         }
         .recover {
-          case e ⇒
+          case e =>
             val time = timeContext.stop()
             pagerDutyAlerting.alert("Failed to make call to uc claimant check")
             metrics.dwpClaimantErrorCounter.inc()
@@ -107,10 +107,10 @@ class DWPConnectorImpl @Inject()(
   }
 
   def healthCheck()(implicit hc: HeaderCarrier, ec: ExecutionContext): EitherT[Future, String, Unit] =
-    EitherT(proxyClient.get(appConfig.dwpHealthCheckURL).map[Either[String, Unit]] { response ⇒
+    EitherT(proxyClient.get(appConfig.dwpHealthCheckURL).map[Either[String, Unit]] { response =>
       response.status match {
-        case Status.OK | Status.NO_CONTENT ⇒ Right(())
-        case other ⇒ Left(s"Received status $other from DWP health/connectivity check. Response body was '${response.body}'")
+        case Status.OK | Status.NO_CONTENT => Right(())
+        case other => Left(s"Received status $other from DWP health/connectivity check. Response body was '${response.body}'")
       }
     })
 

--- a/app/uk.gov.hmrc.helptosaveproxy/connectors/DWPConnector.scala
+++ b/app/uk.gov.hmrc.helptosaveproxy/connectors/DWPConnector.scala
@@ -75,7 +75,7 @@ class DWPConnectorImpl @Inject()(
 
     EitherT(
       proxyClient
-        .get(s"${appConfig.dwpBaseUrl}/hmrc/$nino", queryParams)(hc.copy(authorization = None), ec)
+        .get(s"${appConfig.dwpCheckURL}/$nino", queryParams)(hc.copy(authorization = None), ec)
         .map[Either[String, HttpResponse]] { response ⇒
           val time = timeContext.stop()
           response.status match {
@@ -109,8 +109,8 @@ class DWPConnectorImpl @Inject()(
   def healthCheck()(implicit hc: HeaderCarrier, ec: ExecutionContext): EitherT[Future, String, Unit] =
     EitherT(proxyClient.get(appConfig.dwpHealthCheckURL).map[Either[String, Unit]] { response ⇒
       response.status match {
-        case Status.OK ⇒ Right(())
-        case other ⇒ Left(s"Received status $other from DWP health check. Response body was '${response.body}'")
+        case Status.OK | Status.NO_CONTENT ⇒ Right(())
+        case other ⇒ Left(s"Received status $other from DWP health/connectivity check. Response body was '${response.body}'")
       }
     })
 

--- a/app/uk.gov.hmrc.helptosaveproxy/controllers/HelpToSaveController.scala
+++ b/app/uk.gov.hmrc.helptosaveproxy/controllers/HelpToSaveController.scala
@@ -78,7 +78,7 @@ class HelpToSaveController @Inject()(
         { e =>
           val message = s"Could not retrieve $resource due to : $e"
           logger.warn(message)
-          Status(500)(message)
+          InternalServerError(message)
         }, { response =>
           Option(response.body).fold[Result](Status(response.status))(body => Status(response.status)(body))
         }

--- a/app/uk.gov.hmrc.helptosaveproxy/controllers/HelpToSaveController.scala
+++ b/app/uk.gov.hmrc.helptosaveproxy/controllers/HelpToSaveController.scala
@@ -52,58 +52,58 @@ class HelpToSaveController @Inject()(
   def jsonSchemaValidationToggle(nino: NINO): FEATURE =
     FEATURE("create-account-json-validation", appConfig.runModeConfiguration, logger, Some(nino))
 
-  def createAccount(): Action[AnyContent] = authorised { implicit request ⇒
+  def createAccount(): Action[AnyContent] = authorised { implicit request =>
     processRequest[SubmissionSuccess] {
       nsiConnector.createAccount(_).leftMap[Error](NSIError)
-    } { (submissionSuccess, nSIUserInfo) ⇒
+    } { (submissionSuccess, nSIUserInfo) =>
       submissionSuccess.accountNumber match {
-        case None ⇒ Conflict
-        case Some(account) ⇒ Created(Json.toJson(account))
+        case None => Conflict
+        case Some(account) => Created(Json.toJson(account))
       }
     }
   }
 
-  def updateEmail(): Action[AnyContent] = authorised { implicit request ⇒
+  def updateEmail(): Action[AnyContent] = authorised { implicit request =>
     processRequest[Unit](
-      nsiConnector.updateEmail(_).leftMap[Error](e ⇒ NSIError(SubmissionFailure(e, "Could not update email")))) {
-      (_, _) ⇒
+      nsiConnector.updateEmail(_).leftMap[Error](e => NSIError(SubmissionFailure(e, "Could not update email")))) {
+      (_, _) =>
         Ok
     }
   }
 
-  def queryAccount(resource: String): Action[AnyContent] = authorised { implicit request ⇒
+  def queryAccount(resource: String): Action[AnyContent] = authorised { implicit request =>
     nsiConnector
       .queryAccount(resource, request.queryString)
       .fold(
-        { e ⇒
+        { e =>
           val message = s"Could not retrieve $resource due to : $e"
           logger.warn(message)
           Status(500)(message)
-        }, { response ⇒
-          Option(response.body).fold[Result](Status(response.status))(body ⇒ Status(response.status)(body))
+        }, { response =>
+          Option(response.body).fold[Result](Status(response.status))(body => Status(response.status)(body))
         }
       )
   }
 
   private def processRequest[T](
-    doRequest: NSIPayload ⇒ EitherT[Future, Error, T])(handleResult: (T, NSIPayload) ⇒ Result)(
+    doRequest: NSIPayload => EitherT[Future, Error, T])(handleResult: (T, NSIPayload) => Result)(
     implicit request: Request[AnyContent]): Future[Result] = { // scalastyle:ignore
     val result: EitherT[Future, Error, (T, NSIPayload)] = for {
-      nsiPayload ← EitherT.fromEither[Future](extractNSIPayload(request))
-      _ ← validateAgainstJSONSchema(nsiPayload)
-      response ← doRequest(nsiPayload)
+      nsiPayload <- EitherT.fromEither[Future](extractNSIPayload(request))
+      _ <- validateAgainstJSONSchema(nsiPayload)
+      response <- doRequest(nsiPayload)
     } yield (response, nsiPayload)
 
     result.fold[Result](
       {
-        case InvalidRequest(m, d) ⇒ {
+        case InvalidRequest(m, d) => {
           logger.warn(s"Invalid request: $m, $d")
           BadRequest(SubmissionFailure(m, d).toJson)
         }
-        case NSIError(f) ⇒
+        case NSIError(f) =>
           InternalServerError(f.toJson)
       }, {
-        case (subResult, nsiPayload) ⇒ handleResult(subResult, nsiPayload)
+        case (subResult, nsiPayload) => handleResult(subResult, nsiPayload)
       }
     )
   }
@@ -114,16 +114,16 @@ class HelpToSaveController @Inject()(
     jsonSchemaValidationToggle(payload.nino).thenOrElse(
       EitherT
         .fromEither[Future](jsonSchemaValidationService.validate(json))
-        .leftMap[Error](e ⇒ InvalidRequest("Invalid data found in request", e)),
+        .leftMap[Error](e => InvalidRequest("Invalid data found in request", e)),
       EitherT.pure(json)
     )
   }
 
   private def extractNSIPayload(request: Request[AnyContent]): Either[InvalidRequest, NSIPayload] =
     request.body.asJson.map(_.validate[NSIPayload]) match {
-      case Some(JsSuccess(payload, _)) ⇒ Right(payload)
-      case Some(e: JsError) ⇒ Left(InvalidRequest("Could not parse JSON in request", e.prettyPrint()))
-      case None ⇒ Left(InvalidRequest("No JSON found in request", "JSON body required"))
+      case Some(JsSuccess(payload, _)) => Right(payload)
+      case Some(e: JsError) => Left(InvalidRequest("Could not parse JSON in request", e.prettyPrint()))
+      case None => Left(InvalidRequest("No JSON found in request", "JSON body required"))
 
     }
 

--- a/app/uk.gov.hmrc.helptosaveproxy/controllers/UCClaimantCheckController.scala
+++ b/app/uk.gov.hmrc.helptosaveproxy/controllers/UCClaimantCheckController.scala
@@ -36,14 +36,14 @@ class UCClaimantCheckController @Inject()(
     extends BackendController(cc) with Auth with Logging {
 
   def ucClaimantCheck(nino: String, transactionId: UUID, threshold: Double): Action[AnyContent] = authorised {
-    implicit request ⇒
+    implicit request =>
       dwpConnector
         .ucClaimantCheck(nino, transactionId, threshold)
         .fold(
-          { e ⇒
+          { e =>
             logger.warn(s"Could not perform UC Claimant check: $e")
             InternalServerError
-          }, { r ⇒
+          }, { r =>
             Ok(r.json)
           }
         )

--- a/app/uk.gov.hmrc.helptosaveproxy/health/DWPConnectionHealthCheck.scala
+++ b/app/uk.gov.hmrc.helptosaveproxy/health/DWPConnectionHealthCheck.scala
@@ -57,7 +57,7 @@ class DWPConnectionHealthCheck @Inject()(
       configuration.underlying,
       system.scheduler,
       metrics.metrics,
-      () ⇒ pagerDutyAlerting.alert("DWP health check has failed"),
+      () => pagerDutyAlerting.alert("DWP health check has failed"),
       DWPConnectionHealthCheckRunner.props(dWPConnector, metrics)
     )
   )
@@ -72,7 +72,7 @@ class DWPConnectionHealthCheck @Inject()(
         system.scheduler,
         None,
         _.fold(Some(newHealthCheck()))(Some(_)),
-        _.flatMap { ref ⇒
+        _.flatMap { ref =>
           ref ! PoisonPill
           None
         },
@@ -107,14 +107,14 @@ object DWPConnectionHealthCheck {
       dwpConnector
         .healthCheck()
         .value
-        .map { result ⇒
+        .map { result =>
           val time = timer.stop()
           result.fold[HealthCheckResult](
-            e ⇒ HealthCheckResult.Failure(e, time),
-            _ ⇒ HealthCheckResult.Success("DWP health check returned 200 OK", time))
+            e => HealthCheckResult.Failure(e, time),
+            _ => HealthCheckResult.Success("DWP health check returned 200 OK", time))
         }
         .recover {
-          case NonFatal(e) ⇒
+          case NonFatal(e) =>
             val time = timer.stop()
             HealthCheckResult.Failure(e.getMessage, time)
         }

--- a/app/uk.gov.hmrc.helptosaveproxy/health/HealthCheckRunner.scala
+++ b/app/uk.gov.hmrc.helptosaveproxy/health/HealthCheckRunner.scala
@@ -22,14 +22,14 @@ import uk.gov.hmrc.helptosaveproxy.health.HealthCheck.PerformHealthCheck
 
 import scala.concurrent.Future
 
-trait HealthCheckRunner { this: Actor ⇒
+trait HealthCheckRunner { this: Actor =>
 
   import context.dispatcher
 
   def performTest(): Future[HealthCheckResult]
 
   override def receive: Receive = {
-    case PerformHealthCheck ⇒ performTest() pipeTo sender
+    case PerformHealthCheck => performTest() pipeTo sender
   }
 
 }

--- a/app/uk.gov.hmrc.helptosaveproxy/health/NSIConnectionHealthCheck.scala
+++ b/app/uk.gov.hmrc.helptosaveproxy/health/NSIConnectionHealthCheck.scala
@@ -62,7 +62,7 @@ class NSIConnectionHealthCheck @Inject()(
       configuration.underlying,
       system.scheduler,
       metrics.metrics,
-      () ⇒ pagerDutyAlerting.alert("NSI health check has failed"),
+      () => pagerDutyAlerting.alert("NSI health check has failed"),
       NSIConnectionHealthCheckRunner.props(nSIConnector, metrics, Payload.Payload1, ninoLoggingEnabled),
       NSIConnectionHealthCheckRunner.props(nSIConnector, metrics, Payload.Payload2, ninoLoggingEnabled)
     )
@@ -78,7 +78,7 @@ class NSIConnectionHealthCheck @Inject()(
         system.scheduler,
         None,
         _.fold(Some(newHealthCheck()))(Some(_)),
-        _.flatMap { ref ⇒
+        _.flatMap { ref =>
           ref ! PoisonPill
           None
         },
@@ -123,14 +123,14 @@ object NSIConnectionHealthCheck {
       nsiConnector
         .healthCheck(payload.value)
         .value
-        .map { result ⇒
+        .map { result =>
           val time = timer.stop()
           result.fold[HealthCheckResult](
-            e ⇒ HealthCheckResult.Failure(e, time),
-            _ ⇒ HealthCheckResult.Success(successMessage, time))
+            e => HealthCheckResult.Failure(e, time),
+            _ => HealthCheckResult.Success(successMessage, time))
         }
         .recover {
-          case NonFatal(e) ⇒
+          case NonFatal(e) =>
             val time = timer.stop()
             HealthCheckResult.Failure(e.getMessage, time)
         }

--- a/app/uk.gov.hmrc.helptosaveproxy/http/HttpProxyClient.scala
+++ b/app/uk.gov.hmrc.helptosaveproxy/http/HttpProxyClient.scala
@@ -75,7 +75,7 @@ class HttpProxyClient(
       if (needsAuditing) {
         executeHooks(PUT, new URL(url), headers.toSeq, Option(HookData.FromString(Json.stringify(w.writes(body)))), httpResponse)
       }
-      mapErrors(PUT, url, httpResponse).map(response ⇒ rawHttpReads.read(PUT, url, response))
+      mapErrors(PUT, url, httpResponse).map(response => rawHttpReads.read(PUT, url, response))
     }
 
 }

--- a/app/uk.gov.hmrc.helptosaveproxy/http/HttpProxyClient.scala
+++ b/app/uk.gov.hmrc.helptosaveproxy/http/HttpProxyClient.scala
@@ -21,7 +21,7 @@ import play.api.Configuration
 import play.api.http.HttpVerbs
 import play.api.libs.json.{Json, Writes}
 import play.api.libs.ws.{WSClient, WSProxyServer}
-import uk.gov.hmrc.http.hooks.HookData
+import uk.gov.hmrc.http.hooks.{Data, HookData, RequestData, ResponseData}
 import uk.gov.hmrc.http.{HeaderCarrier, HttpReads, HttpResponse}
 import uk.gov.hmrc.play.audit.http.HttpAuditing
 import uk.gov.hmrc.play.bootstrap.http.DefaultHttpClient
@@ -73,7 +73,7 @@ class HttpProxyClient(
     withTracing(PUT, url) {
       val httpResponse = doPut(url, body, headers.toSeq)(w, ec)
       if (needsAuditing) {
-        executeHooks(PUT, new URL(url), headers.toSeq, Option(HookData.FromString(Json.stringify(w.writes(body)))), httpResponse)
+        executeHooks(PUT, new URL(url), RequestData(headers.toSeq, Option(Data(HookData.FromString(Json.stringify(w.writes(body))), isTruncated = false, isRedacted = false))), httpResponse.map(ResponseData.fromHttpResponse))
       }
       mapErrors(PUT, url, httpResponse).map(response => rawHttpReads.read(PUT, url, response))
     }

--- a/app/uk.gov.hmrc.helptosaveproxy/http/HttpProxyClient.scala
+++ b/app/uk.gov.hmrc.helptosaveproxy/http/HttpProxyClient.scala
@@ -73,7 +73,9 @@ class HttpProxyClient(
     withTracing(PUT, url) {
       val httpResponse = doPut(url, body, headers.toSeq)(w, ec)
       if (needsAuditing) {
-        executeHooks(PUT, new URL(url), RequestData(headers.toSeq, Option(Data(HookData.FromString(Json.stringify(w.writes(body))), isTruncated = false, isRedacted = false))), httpResponse.map(ResponseData.fromHttpResponse))
+        executeHooks(PUT, new URL(url),
+          RequestData(headers.toSeq, Option(Data(HookData.FromString(Json.stringify(w.writes(body))), isTruncated = false, isRedacted = false))),
+          httpResponse.map(ResponseData.fromHttpResponse))
       }
       mapErrors(PUT, url, httpResponse).map(response => rawHttpReads.read(PUT, url, response))
     }

--- a/app/uk.gov.hmrc.helptosaveproxy/http/NewWSModule.scala
+++ b/app/uk.gov.hmrc.helptosaveproxy/http/NewWSModule.scala
@@ -76,9 +76,9 @@ class AsyncHttpClientProvider @Inject()(
     val cacheProvider = new OptionalAhcHttpCacheProvider(environment, configuration, applicationLifecycle)
     val client = new DefaultAsyncHttpClient(asyncHttpClientConfig)
     cacheProvider.get match {
-      case Some(ahcHttpCache) ⇒
+      case Some(ahcHttpCache) =>
         new CachingAsyncHttpClient(client, ahcHttpCache)
-      case None ⇒
+      case None =>
         client
     }
   }
@@ -106,7 +106,7 @@ class AsyncHttpClientProvider @Inject()(
   }
 
   // Always close the AsyncHttpClient afterwards.
-  applicationLifecycle.addStopHook(() ⇒ Future.successful(get.close()))
+  applicationLifecycle.addStopHook(() => Future.successful(get.close()))
 }
 
 /**
@@ -124,7 +124,7 @@ class OptionalAhcHttpCacheProvider @Inject()(
     extends Provider[Option[AhcHttpCache]] {
 
   lazy val get: Option[AhcHttpCache] = {
-    optionalCache.map { cache ⇒
+    optionalCache.map { cache =>
       new AhcHttpCache(cache, cacheConfig.heuristicsEnabled)
     }
   }
@@ -142,23 +142,23 @@ class OptionalAhcHttpCacheProvider @Inject()(
       val cacheManager: CacheManager = {
         val cachingProvider =
           cacheConfig.cachingProviderName match {
-            case name if name.nonEmpty ⇒
+            case name if name.nonEmpty =>
               Caching.getCachingProvider(name, environment.classLoader)
-            case _ ⇒
+            case _ =>
               Caching.getCachingProvider(environment.classLoader)
           }
         val cacheManagerURI =
           cacheConfig.cacheManagerURI match {
-            case uriString if uriString.nonEmpty ⇒ new URI(uriString)
+            case uriString if uriString.nonEmpty => new URI(uriString)
             // null means use #getDefaultURI
-            case _ ⇒ null
+            case _ => null
           }
         cachingProvider.getCacheManager(cacheManagerURI, environment.classLoader)
       }
 
-      Option(cacheManager).map { cm ⇒
+      Option(cacheManager).map { cm =>
         val jcache = getOrCreateCache(cm)
-        applicationLifecycle.addStopHook(() ⇒ Future.successful(jcache.close()))
+        applicationLifecycle.addStopHook(() => Future.successful(jcache.close()))
         new JCacheAdapter(jcache)
       }
     } else {
@@ -218,13 +218,13 @@ class OptionalAhcHttpCacheProvider @Inject()(
     // Treat cacheManagerResource as a resource on the classpath and convert it to an URI string.
     def fromConfiguration(configuration: Configuration): AhcHttpCacheConfiguration = {
       val cacheManagerURI = configuration.get[Option[String]]("play.ws.cache.cacheManagerURI") match {
-        case Some(uriString) ⇒
+        case Some(uriString) =>
           Logger(AhcHttpCacheParser.getClass)
             .warn(
               "play.ws.cache.cacheManagerURI is deprecated, use play.ws.cache.cacheManagerResource with a path on the classpath instead."
             )
           uriString
-        case None ⇒
+        case None =>
           configuration
             .get[Option[String]]("play.ws.cache.cacheManagerResource")
             .filter(_.nonEmpty)

--- a/app/uk.gov.hmrc.helptosaveproxy/metrics/Metrics.scala
+++ b/app/uk.gov.hmrc.helptosaveproxy/metrics/Metrics.scala
@@ -59,18 +59,18 @@ class Metrics @Inject()(val metrics: com.kenshoo.play.metrics.Metrics) {
 object Metrics {
 
   private val timeWordToDenomination = List(
-    "ns" → 1000L,
-    "μs" → 1000L,
-    "ms" → 1000L,
-    "s" → 60L,
-    "m" → 60L,
-    "h" → 24L,
-    "d" → 7L
+    "ns" -> 1000L,
+    "μs" -> 1000L,
+    "ms" -> 1000L,
+    "s" -> 60L,
+    "m" -> 60L,
+    "h" -> 24L,
+    "d" -> 7L
   )
 
   /** Return the integer part and the remainder of the result of dividing th enumerator by the denominator */
   private def divide(numerator: Long, denominator: Long): (Long, Long) =
-    (numerator / denominator) → (numerator % denominator)
+    (numerator / denominator) -> (numerator % denominator)
 
   /**
     * Convert `nanos` to a human-friendly string - will return the time in terms of
@@ -83,25 +83,25 @@ object Metrics {
 
     @tailrec
     def loop(l: List[(String, Long)], t: Long, acc: List[(Long, String)]): List[(Long, String)] = l match {
-      case Nil ⇒
+      case Nil =>
         acc
 
-      case (word, number) :: tail ⇒
+      case (word, number) :: tail =>
         if (t < number) {
-          (t → word) :: acc
+          (t -> word) :: acc
         } else {
           val (remaining, currentUnits) = divide(t, number)
 
           if (currentUnits === 0L) {
             loop(tail, remaining, acc)
           } else {
-            loop(tail, remaining, (currentUnits → word) :: acc)
+            loop(tail, remaining, (currentUnits -> word) :: acc)
           }
         }
     }
 
     val result = loop(timeWordToDenomination, nanos, List.empty[(Long, String)])
-    result.take(2).map(x ⇒ s"${x._1}${x._2}").mkString(" ")
+    result.take(2).map(x => s"${x._1}${x._2}").mkString(" ")
   }
 
 }

--- a/app/uk.gov.hmrc.helptosaveproxy/models/NSIPayload.scala
+++ b/app/uk.gov.hmrc.helptosaveproxy/models/NSIPayload.scala
@@ -66,13 +66,13 @@ object NSIPayload {
     override def writes(o: LocalDate): JsValue = JsString(o.format(formatter))
 
     override def reads(json: JsValue): JsResult[LocalDate] = json match {
-      case JsString(s) ⇒
+      case JsString(s) =>
         Try(LocalDate.parse(s, formatter)) match {
-          case Success(date) ⇒ JsSuccess(date)
-          case Failure(error) ⇒ JsError(s"Could not parse date as yyyyMMdd: ${error.getMessage}")
+          case Success(date) => JsSuccess(date)
+          case Failure(error) => JsError(s"Could not parse date as yyyyMMdd: ${error.getMessage}")
         }
 
-      case other ⇒ JsError(s"Expected string but got $other")
+      case other => JsError(s"Expected string but got $other")
     }
   }
 
@@ -86,7 +86,7 @@ object NSIPayload {
     override def writes(o: NSIPayload): JsValue = writes.writes(o)
 
     @SuppressWarnings(Array("org.wartremover.warts.PlatformDefault"))
-    override def reads(json: JsValue): JsResult[NSIPayload] = reads.reads(json).map { u ⇒
+    override def reads(json: JsValue): JsResult[NSIPayload] = reads.reads(json).map { u =>
       val c = u.contactDetails
       NSIPayload(
         u.forename.cleanupSpecialCharacters,

--- a/app/uk.gov.hmrc.helptosaveproxy/services/JSONSchemaValidationService.scala
+++ b/app/uk.gov.hmrc.helptosaveproxy/services/JSONSchemaValidationService.scala
@@ -57,30 +57,30 @@ class JSONSchemaValidationServiceImpl @Inject()(conf: Configuration) extends JSO
 
   private def extractDateOfBirth(userInfo: JsValue): Either[String, LocalDate] =
     (userInfo \ "dateOfBirth").toEither.fold[Either[String, LocalDate]](
-      _ ⇒ Left("No date of birth found"), {
-        case JsString(s) ⇒
+      _ => Left("No date of birth found"), {
+        case JsString(s) =>
           Try(LocalDate.parse(s, dateFormatter)) match {
-            case Failure(e) ⇒ Left(s"Could not parse date of birth: ${e.getMessage}")
-            case Success(value) ⇒ Right(value)
+            case Failure(e) => Left(s"Could not parse date of birth: ${e.getMessage}")
+            case Success(value) => Right(value)
           }
 
-        case _ ⇒ Left("Date of birth was not a string")
+        case _ => Left("Date of birth was not a string")
       }
     )
 
   private def validateAgainstSchema(userInfo: JsValue): Either[String, JsValue] =
     jsonValidator.validate(validationSchema, userInfo) match {
-      case e: JsError ⇒
+      case e: JsError =>
         Left(s"The following fields were either invalid or missing: [${e.errors.map(_._1.toJsonString).mkString(",")}]")
-      case JsSuccess(u, _) ⇒ Right(u)
+      case JsSuccess(u, _) => Right(u)
     }
 
   def validate(payload: JsValue): Either[String, JsValue] =
     for {
-      u ← validateAgainstSchema(payload)
-      d ← extractDateOfBirth(payload)
-      _ ← futureDate(d)
-      _ ← before1800(d)
+      u <- validateAgainstSchema(payload)
+      d <- extractDateOfBirth(payload)
+      _ <- futureDate(d)
+      _ <- before1800(d)
     } yield u
 
 }

--- a/app/uk.gov.hmrc.helptosaveproxy/util/HttpResponseOps.scala
+++ b/app/uk.gov.hmrc.helptosaveproxy/util/HttpResponseOps.scala
@@ -31,20 +31,20 @@ class HttpResponseOps(val response: HttpResponse) extends AnyVal {
 
   def parseJSON[A](path: Option[String] = None)(implicit reads: Reads[A]): Either[String, A] =
     Try(path.fold[JsLookupResult](JsDefined(response.json))(response.json \ _)) match {
-      case Success(jsLookupResult) ⇒
+      case Success(jsLookupResult) =>
         // use Option here to filter out null values
         jsLookupResult.toOption
           .flatMap(Option(_))
           .fold[Either[String, A]](
             Left("No JSON found in body of http response")
           )(_.validate[A].fold[Either[String, A]](
-            errors ⇒
+            errors =>
               // there was JSON in the response but we couldn't read it
               Left(s"Could not parse http response JSON: ${JsError(errors)
                 .prettyPrint()}. Response body was ${maskNino(response.body)}}"),
             Right(_)
           ))
-      case Failure(error) ⇒
+      case Failure(error) =>
         // response.json failed in this case - there was no JSON in the response
         Left(s"Could not read http response as JSON: ${error.getMessage}. Response body was ${maskNino(response.body)}")
     }

--- a/app/uk.gov.hmrc.helptosaveproxy/util/JsErrorOps.scala
+++ b/app/uk.gov.hmrc.helptosaveproxy/util/JsErrorOps.scala
@@ -34,7 +34,7 @@ class JsErrorOps(val error: JsError) extends AnyVal {
   def prettyPrint(): String =
     error.errors
       .map {
-        case (jsPath, validationErrors) ⇒
+        case (jsPath, validationErrors) =>
           jsPath.toString + ": [" + validationErrors.map(_.message).mkString(",") + "]"
       }
       .mkString("; ")

--- a/app/uk.gov.hmrc.helptosaveproxy/util/Logging.scala
+++ b/app/uk.gov.hmrc.helptosaveproxy/util/Logging.scala
@@ -41,7 +41,7 @@ object Logging {
       implicit transformer: LogMessageTransformer): Unit =
       logger.warn(transformer.transform(message, nino, correlationId))
 
-    def warn(message: String, e: ⇒ Throwable, nino: NINO, correlationId: Option[String])(
+    def warn(message: String, e: => Throwable, nino: NINO, correlationId: Option[String])(
       implicit transformer: LogMessageTransformer): Unit =
       logger.warn(transformer.transform(message, nino, correlationId), e)
 
@@ -49,7 +49,7 @@ object Logging {
       implicit transformer: LogMessageTransformer): Unit =
       logger.error(transformer.transform(message, nino, correlationId))
 
-    def error(message: String, e: ⇒ Throwable, nino: NINO, correlationId: Option[String])(
+    def error(message: String, e: => Throwable, nino: NINO, correlationId: Option[String])(
       implicit transformer: LogMessageTransformer): Unit =
       logger.error(transformer.transform(message, nino, correlationId), e)
 
@@ -65,16 +65,16 @@ trait LogMessageTransformer {
 @Singleton
 class LogMessageTransformerImpl @Inject()(configuration: Configuration) extends LogMessageTransformer {
 
-  private val ninoPrefix: NINO ⇒ String =
-    if (configuration.underlying.getBoolean("nino-logging.enabled")) { nino ⇒
+  private val ninoPrefix: NINO => String =
+    if (configuration.underlying.getBoolean("nino-logging.enabled")) { nino =>
       s"For NINO [$nino], "
-    } else { _ ⇒
+    } else { _ =>
       ""
     }
 
-  private val correlationIdPrefix: Option[String] ⇒ String = {
-    case Some(id) ⇒ s"for CorrelationId $id, "
-    case None ⇒ ""
+  private val correlationIdPrefix: Option[String] => String = {
+    case Some(id) => s"for CorrelationId $id, "
+    case None => ""
   }
 
   def transform(message: String, nino: NINO, correlationId: Option[String]): String =

--- a/app/uk.gov.hmrc.helptosaveproxy/util/Toggles.scala
+++ b/app/uk.gov.hmrc.helptosaveproxy/util/Toggles.scala
@@ -34,13 +34,13 @@ object Toggles {
 
     @inline private def time(): Long = System.nanoTime()
 
-    def thenOrElse[A](ifEnabled: ⇒ A, ifDisabled: ⇒ A)(implicit transformer: LogMessageTransformer): A = {
+    def thenOrElse[A](ifEnabled: => A, ifDisabled: => A)(implicit transformer: LogMessageTransformer): A = {
       val start = time()
       val result = if (enabled) ifEnabled else ifDisabled
       val end = time()
       nino.fold(
         logger.info(s"Feature $name (enabled: $enabled) executed in ${nanosToPrettyString(end - start)}")
-      )(n ⇒ logger.info(s"Feature $name (enabled: $enabled) executed in ${nanosToPrettyString(end - start)}", n, None))
+      )(n => logger.info(s"Feature $name (enabled: $enabled) executed in ${nanosToPrettyString(end - start)}", n, None))
       result
     }
 

--- a/app/uk.gov.hmrc.helptosaveproxy/util/lock/Lock.scala
+++ b/app/uk.gov.hmrc.helptosaveproxy/util/lock/Lock.scala
@@ -92,9 +92,12 @@ class Lock[State](
     // release the lock when the application shuts down
     registerStopHook { () =>
       if (lockAcquired) {
-        lock.withRenewedLock[Unit]().onComplete {
+        lock.withRenewedLock[Unit]((): Unit).onComplete {
           case Success(_) =>
             logger.info("Successfully released lock")
+
+
+
             state = onLockReleased(state)
           case Failure(e) =>
             logger.warn(s"Could not release lock: ${e.getMessage}")

--- a/app/uk.gov.hmrc.helptosaveproxy/util/lock/Lock.scala
+++ b/app/uk.gov.hmrc.helptosaveproxy/util/lock/Lock.scala
@@ -102,7 +102,7 @@ class Lock[State](
       }
     }
 
-    schedulerTask = Some(scheduler.scheduleAtFixedRate(Duration.Zero, Duration.fromNanos(lock.ttl.toMillis), self, AcquireLock))
+    schedulerTask = Some(scheduler.scheduleAtFixedRate(Duration.Zero, Duration.fromNanos(lock.ttl.toNanos), self, AcquireLock))
   }
 
 }

--- a/app/uk.gov.hmrc.helptosaveproxy/util/lock/Lock.scala
+++ b/app/uk.gov.hmrc.helptosaveproxy/util/lock/Lock.scala
@@ -47,9 +47,9 @@ class Lock[State](
   lock: TimePeriodLockService,
   scheduler: Scheduler,
   initialState: State,
-  onLockAcquired: State ⇒ State,
-  onLockReleased: State ⇒ State,
-  registerStopHook: (() ⇒ Future[Unit]) ⇒ Unit)
+  onLockAcquired: State => State,
+  onLockReleased: State => State,
+  registerStopHook: (() => Future[Unit]) => Unit)
     extends Actor with Logging {
 
   import Lock.LockMessages._
@@ -63,17 +63,17 @@ class Lock[State](
   var lockAcquired: Boolean = false
 
   override def receive: Receive = {
-    case AcquireLock ⇒
+    case AcquireLock =>
       val result = lock.withRenewedLock[Unit](toFuture(()))
-        .map(result ⇒ AcquireLockResult(result.isDefined))
-        .recover { case NonFatal(e) ⇒ AcquireLockFailure(e) }
+        .map(result => AcquireLockResult(result.isDefined))
+        .recover { case NonFatal(e) => AcquireLockFailure(e) }
 
       result pipeTo self
 
-    case AcquireLockFailure(error) ⇒
+    case AcquireLockFailure(error) =>
       logger.warn(s"Could not acquire or renew lock: ${error.getMessage}. Leaving state as is")
 
-    case AcquireLockResult(acquired) ⇒
+    case AcquireLockResult(acquired) =>
       if (acquired) {
         logger.info(s"Lock successfully acquired (lockID: ${lock.lockId}")
         lockAcquired = true
@@ -90,13 +90,13 @@ class Lock[State](
     super.preStart()
 
     // release the lock when the application shuts down
-    registerStopHook { () ⇒
+    registerStopHook { () =>
       if (lockAcquired) {
         lock.withRenewedLock[Unit]().onComplete {
-          case Success(_) ⇒
+          case Success(_) =>
             logger.info("Successfully released lock")
             state = onLockReleased(state)
-          case Failure(e) ⇒
+          case Failure(e) =>
             logger.warn(s"Could not release lock: ${e.getMessage}")
         }
       }
@@ -118,8 +118,8 @@ object Lock {
     lockDuration: FiniteDuration,
     scheduler: Scheduler,
     initialState: State,
-    onLockAcquired: State ⇒ State,
-    onLockReleased: State ⇒ State,
+    onLockAcquired: State => State,
+    onLockReleased: State => State,
     mongoLockRepository: MongoLockRepository,
     lifecycle: ApplicationLifecycle): Props = {
 

--- a/app/uk.gov.hmrc.helptosaveproxy/util/package.scala
+++ b/app/uk.gov.hmrc.helptosaveproxy/util/package.scala
@@ -42,8 +42,8 @@ package object util {
 
   def maskNino(original: String): String =
     Option(original) match {
-      case Some(text) ⇒ ninoRegex.replaceAllIn(text, "<NINO>")
-      case None ⇒ original
+      case Some(text) => ninoRegex.replaceAllIn(text, "<NINO>")
+      case None => original
     }
 
   def base64Decode(input: String): Array[Byte] = Base64.getDecoder.decode(input)

--- a/build.sbt
+++ b/build.sbt
@@ -56,7 +56,7 @@ lazy val microservice =
     .settings(majorVersion := 2)
     .settings(publishingSettings: _*)
     .settings(defaultSettings(): _*)
-    .settings(scalaVersion := "2.12.13")
+    .settings(scalaVersion := "2.12.16")
     .settings(PlayKeys.playDefaultPort := 7005)
     .settings(wartRemoverSettings)
     // disable some wart remover checks in tests - (Any, Null, PublicInference) seems to struggle with

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -211,6 +211,8 @@ microservice {
       host = localhost
       port = 7002
       system-id = 607
+      check = "hmrc"
+      health-check = "hmrc-healthcheck"
       client {
         base64KeystoreType = "pkcs12"
         base64KeystorePassword = ""

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -6,27 +6,27 @@ object AppDependencies {
 
   val compile = Seq(
     ws,
-    "uk.gov.hmrc"       %% "domain"                     % "6.2.0-play-28",
-    "uk.gov.hmrc"       %% "bootstrap-backend-play-28"  % "5.10.0",
-    "uk.gov.hmrc.mongo" %% "hmrc-mongo-play-28"      % "0.70.0",
+    "uk.gov.hmrc"       %% "domain"                     % "8.1.0-play-28",
+    "uk.gov.hmrc"       %% "bootstrap-backend-play-28"  % "7.11.0",
+    "uk.gov.hmrc.mongo" %% "hmrc-mongo-play-28"         % "0.73.0",
     "com.eclipsesource" %% "play-json-schema-validator" % "0.9.4",
-    "org.typelevel"     %% "cats-core"                  % "2.5.0",
-    "com.github.kxbmap" %% "configs"                     % "0.6.0",
-    compilerPlugin("com.github.ghik" % "silencer-plugin" % "1.7.1" cross CrossVersion.full),
-    "com.github.ghik" % "silencer-lib" % "1.7.1" % Provided cross CrossVersion.full
+    "org.typelevel"     %% "cats-core"                  % "2.8.0",
+    "com.github.kxbmap" %% "configs"                    % "0.6.1",
+    compilerPlugin("com.github.ghik" % "silencer-plugin" % "1.7.12" cross CrossVersion.full),
+    "com.github.ghik" % "silencer-lib" % "1.7.12" % Provided cross CrossVersion.full
   )
 
   val test = Seq(
     "uk.gov.hmrc"          %% "stub-data-generator"         % "0.5.3"             % "test",
-    "org.scalatest"        %% "scalatest"                   % "3.2.8"             % "test",
-    "com.vladsch.flexmark"  %  "flexmark-all"                 % "0.35.10"           % "test",
+    "org.scalatest"        %% "scalatest"                   % "3.2.14"            % "test",
+    "com.vladsch.flexmark" %  "flexmark-all"                % "0.62.2"            % "test",
     "org.scalatestplus"    %% "scalatestplus-scalacheck"    % "3.1.0.0-RC2"       % "test",
     "org.pegdown"          %  "pegdown"                     % "1.6.0"             % "test",
     "com.typesafe.play"    %% "play-test"                   % PlayVersion.current % "test",
-    "uk.gov.hmrc.mongo" %% "hmrc-mongo-test-play-28" % "0.70.0" % "test",
+    "uk.gov.hmrc.mongo"    %% "hmrc-mongo-test-play-28"     % "0.73.0"            % "test",
     "org.scalamock"        %% "scalamock-scalatest-support" % "3.6.0"             % "test",
     "com.miguno.akka"      %% "akka-mock-scheduler"         % "0.5.5"             % "test",
-    "com.typesafe.akka"    %% "akka-testkit"                % "2.6.14"            % "test"
+    "com.typesafe.akka"    %% "akka-testkit"                % "2.6.20"            % "test"
   )
 
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.5.2
+sbt.version=1.7.2

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -4,18 +4,18 @@ resolvers += Resolver.jcenterRepo
 resolvers += "Typesafe Releases" at "https://repo.typesafe.com/typesafe/releases/"
 resolvers += Resolver.url("scoverage-bintray", url("https://dl.bintray.com/sksamuel/sbt-plugins/"))(Resolver.ivyStylePatterns)
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "3.0.0")
+addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "3.8.0")
 
 addSbtPlugin("uk.gov.hmrc" % "sbt-distributables" % "2.1.0")
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-bobby" % "3.5.0")
+addSbtPlugin("uk.gov.hmrc" % "sbt-bobby" % "4.2.0")
 
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.8")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.18")
 
-addSbtPlugin("org.scoverage" %% "sbt-scoverage" % "1.8.1")
+addSbtPlugin("org.scoverage" %% "sbt-scoverage" % "2.0.0")
 
 addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "1.0.0")
 
-addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.2")
+addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.6")
 
-addSbtPlugin("org.wartremover" % "sbt-wartremover" % "2.4.13")
+addSbtPlugin("org.wartremover" % "sbt-wartremover" % "3.0.6")

--- a/test/uk/gov/hmrc/helptosaveproxy/TestSupport.scala
+++ b/test/uk/gov/hmrc/helptosaveproxy/TestSupport.scala
@@ -36,7 +36,7 @@ import uk.gov.hmrc.http.{Authorization, SessionId}
 
 import scala.concurrent.ExecutionContext
 
-trait TestSupport extends UnitSpec with MockFactory with BeforeAndAfterAll with ScalaFutures { this: Suite ⇒
+trait TestSupport extends UnitSpec with MockFactory with BeforeAndAfterAll with ScalaFutures { this: Suite =>
 
   lazy val additionalConfig = Configuration()
 

--- a/test/uk/gov/hmrc/helptosaveproxy/auth/AuthSpec.scala
+++ b/test/uk/gov/hmrc/helptosaveproxy/auth/AuthSpec.scala
@@ -39,7 +39,7 @@ class AuthSpec extends AuthSupport {
 
   val retrieve: Retrieval[Option[Credentials]] = credentials
 
-  private def callAuth = auth.authorised { _ ⇒
+  private def callAuth = auth.authorised { _ =>
     Future.successful(Ok("authSuccess"))
   }
 
@@ -56,21 +56,21 @@ class AuthSpec extends AuthSupport {
       def mockAuthWith(error: String) = mockAuthResultWithFail()(fromString(error))
 
       val exceptions = List(
-        "InsufficientConfidenceLevel" → Status.FORBIDDEN,
-        "InsufficientEnrolments" → Status.FORBIDDEN,
-        "UnsupportedAffinityGroup" → Status.FORBIDDEN,
-        "UnsupportedCredentialRole" → Status.FORBIDDEN,
-        "UnsupportedAuthProvider" → Status.FORBIDDEN,
-        "BearerTokenExpired" → Status.UNAUTHORIZED,
-        "MissingBearerToken" → Status.UNAUTHORIZED,
-        "InvalidBearerToken" → Status.UNAUTHORIZED,
-        "SessionRecordNotFound" → Status.UNAUTHORIZED,
-        "IncorrectCredentialStrength" → Status.FORBIDDEN,
-        "unknown-blah" → Status.INTERNAL_SERVER_ERROR
+        "InsufficientConfidenceLevel" -> Status.FORBIDDEN,
+        "InsufficientEnrolments" -> Status.FORBIDDEN,
+        "UnsupportedAffinityGroup" -> Status.FORBIDDEN,
+        "UnsupportedCredentialRole" -> Status.FORBIDDEN,
+        "UnsupportedAuthProvider" -> Status.FORBIDDEN,
+        "BearerTokenExpired" -> Status.UNAUTHORIZED,
+        "MissingBearerToken" -> Status.UNAUTHORIZED,
+        "InvalidBearerToken" -> Status.UNAUTHORIZED,
+        "SessionRecordNotFound" -> Status.UNAUTHORIZED,
+        "IncorrectCredentialStrength" -> Status.FORBIDDEN,
+        "unknown-blah" -> Status.INTERNAL_SERVER_ERROR
       )
 
       exceptions.foreach {
-        case (error, expectedStatus) ⇒
+        case (error, expectedStatus) =>
           mockAuthWith(error)
           val result = callAuth(FakeRequest())
           status(result) shouldBe expectedStatus

--- a/test/uk/gov/hmrc/helptosaveproxy/connectors/HttpSupport.scala
+++ b/test/uk/gov/hmrc/helptosaveproxy/connectors/HttpSupport.scala
@@ -24,7 +24,7 @@ import uk.gov.hmrc.http.{HeaderCarrier, HttpResponse}
 import scala.concurrent.{ExecutionContext, Future}
 import org.scalatest.matchers.should.Matchers
 
-trait HttpSupport { this: MockFactory with Matchers ⇒
+trait HttpSupport { this: MockFactory with Matchers =>
 
   val mockProxyClient: HttpProxyClient
 
@@ -35,7 +35,7 @@ trait HttpSupport { this: MockFactory with Matchers ⇒
     (mockProxyClient
       .get(_: String, _: Seq[(String, String)], _: Map[String, String])(_: HeaderCarrier, _: ExecutionContext))
       .expects(where {
-        (u: String, q: Seq[(String, String)], hdrs: Map[String, String], h: HeaderCarrier, _: ExecutionContext) ⇒
+        (u: String, q: Seq[(String, String)], hdrs: Map[String, String], h: HeaderCarrier, _: ExecutionContext) =>
           // use matchers here to get useful error messages when the following predicates
           // are not satisfied - otherwise it is difficult to tell in the logs what went wrong
           u shouldBe url
@@ -50,7 +50,7 @@ trait HttpSupport { this: MockFactory with Matchers ⇒
     (mockProxyClient
       .put(_: String, _: A, _: Map[String, String], _: Boolean)(_: Writes[A], _: HeaderCarrier, _: ExecutionContext))
       .expects(where {
-        (u: String, a: A, hdrs: Map[String, String], n: Boolean, _: Writes[A], h: HeaderCarrier, _: ExecutionContext) ⇒
+        (u: String, a: A, hdrs: Map[String, String], n: Boolean, _: Writes[A], h: HeaderCarrier, _: ExecutionContext) =>
           u shouldBe url
           a shouldBe body
           hdrs shouldBe headers

--- a/test/uk/gov/hmrc/helptosaveproxy/connectors/NSIConnectorSpec.scala
+++ b/test/uk/gov/hmrc/helptosaveproxy/connectors/NSIConnectorSpec.scala
@@ -43,7 +43,7 @@ class NSIConnectorSpec
     extends TestSupport with HttpSupport with MockFactory with ScalaCheckDrivenPropertyChecks with MockPagerDuty {
 
   override lazy val additionalConfig = Configuration(
-    "feature-toggles.log-account-creation-json.enabled" → Random.nextBoolean())
+    "feature-toggles.log-account-creation-json.enabled" -> Random.nextBoolean())
 
   private val mockAuditor = mock[HttpAuditing]
   private val mockWsClient = mock[WSClient]
@@ -66,7 +66,7 @@ class NSIConnectorSpec
   val nsiCreateAccountUrl = appConfig.nsiCreateAccountUrl
   val nsiAuthHeaderKey = appConfig.nsiAuthHeaderKey
   val nsiBasicAuth = appConfig.nsiBasicAuth
-  val authHeaders = Map(nsiAuthHeaderKey → nsiBasicAuth)
+  val authHeaders = Map(nsiAuthHeaderKey -> nsiBasicAuth)
   val noHeaders = Map[String, Seq[String]]()
 
   "the updateEmail method" must {
@@ -81,7 +81,7 @@ class NSIConnectorSpec
 
     "return a Left " when {
       "the status is not OK" in {
-        forAll { status: Int ⇒
+        forAll { status: Int =>
           whenever(status =!= Status.OK && status > 0) {
             inSequence {
               mockPut(nsiCreateAccountUrl, validNSIPayload, authHeaders)(Some(HttpResponse(status, "")))
@@ -127,7 +127,7 @@ class NSIConnectorSpec
         val submissionFailure = SubmissionFailure(Some("id"), "message", "detail")
         inSequence {
           mockPost(nsiCreateAccountUrl, validNSIPayload, authHeaders)(
-            Some(HttpResponse(Status.BAD_REQUEST, JsObject(Seq("error" → submissionFailure.toJson)), noHeaders)))
+            Some(HttpResponse(Status.BAD_REQUEST, JsObject(Seq("error" -> submissionFailure.toJson)), noHeaders)))
           // WARNING: do not change the message in the following check - this needs to stay in line with the configuration in alert-config
           mockPagerDutyAlert("Received unexpected http status in response to create account")
         }
@@ -172,8 +172,8 @@ class NSIConnectorSpec
 
         }
         Await.result(doRequest.value, 3.seconds) match {
-          case Right(_) ⇒ fail()
-          case Left(_) ⇒ ()
+          case Right(_) => fail()
+          case Left(_) => ()
         }
       }
 
@@ -196,7 +196,7 @@ class NSIConnectorSpec
       }
 
       "Return a Left when the status is not OK" in {
-        forAll { status: Int ⇒
+        forAll { status: Int =>
           whenever(status > 0 && status =!= Status.OK) {
             mockPut(nsiCreateAccountUrl, validNSIPayload, authHeaders)(Some(HttpResponse(status, "")))
             Await.result(doRequest.value, 3.seconds).isLeft shouldBe true
@@ -216,10 +216,10 @@ class NSIConnectorSpec
     val resource = "account"
 
     val queryParameters = Map(
-      "nino" → Seq(nino),
-      "version" → Seq(version),
-      "systemId" → Seq(systemId),
-      "correlationId" → Seq(correlationId.toString)
+      "nino" -> Seq(nino),
+      "version" -> Seq(version),
+      "systemId" -> Seq(systemId),
+      "correlationId" -> Seq(correlationId.toString)
     )
 
     val queryParamsSeq =
@@ -239,7 +239,7 @@ class NSIConnectorSpec
     }
 
     "handle unexpected errors" in {
-      forAll { status: Int ⇒
+      forAll { status: Int =>
         whenever(status > 0 && status =!= Status.OK && status =!= Status.BAD_REQUEST) {
           mockGet(url, queryParamsSeq, authHeaders)(Some(HttpResponse(status, "")))
           Await.result(doRequest.value, 3.seconds).isLeft shouldBe true

--- a/test/uk/gov/hmrc/helptosaveproxy/controllers/HelpToSaveControllerSpec.scala
+++ b/test/uk/gov/hmrc/helptosaveproxy/controllers/HelpToSaveControllerSpec.scala
@@ -51,7 +51,7 @@ class HelpToSaveControllerSpec extends AuthSupport {
     (mockJsonSchema
       .validate(_: JsValue))
       .expects(Json.toJson(expectedInfo))
-      .returning(result.map(_ ⇒ Json.toJson(expectedInfo)))
+      .returning(result.map(_ => Json.toJson(expectedInfo)))
 
   def mockCreateAccount(expectedInfo: NSIPayload)(result: Either[SubmissionFailure, SubmissionSuccess]): Unit =
     (mockNSIConnector
@@ -78,11 +78,11 @@ class HelpToSaveControllerSpec extends AuthSupport {
 
     def doCreateAccountRequest(userInfo: NSIPayload) =
       controller.createAccount()(
-        FakeRequest().withJsonBody(Json.toJson(userInfo)).withHeaders("X-Correlation-Id" → correlationId))
+        FakeRequest().withJsonBody(Json.toJson(userInfo)).withHeaders("X-Correlation-Id" -> correlationId))
 
     behave like commonBehaviour(
       controller.createAccount,
-      () ⇒ mockCreateAccount(validNSIPayload)(Left(SubmissionFailure("", ""))),
+      () => mockCreateAccount(validNSIPayload)(Left(SubmissionFailure("", ""))),
       validNSIPayload)
 
     "return a Created status when valid json is given for an eligible new user" in {
@@ -116,7 +116,7 @@ class HelpToSaveControllerSpec extends AuthSupport {
 
     val updatePayload = validNSIPayload.copy(version = None, systemId = None)
 
-    behave like commonBehaviour(controller.updateEmail, () ⇒ mockUpdateEmail(updatePayload)(Left("")), updatePayload)
+    behave like commonBehaviour(controller.updateEmail, () => mockUpdateEmail(updatePayload)(Left("")), updatePayload)
 
     "return an OK status when a user successfully updates their email address" in {
       inSequence {
@@ -141,10 +141,10 @@ class HelpToSaveControllerSpec extends AuthSupport {
     val resource = "account"
 
     val queryParameters = Map(
-      "nino" → Seq(nino),
-      "version" → Seq(version),
-      "systemId" → Seq(systemId),
-      "correlationId" → Seq(correlationId.toString)
+      "nino" -> Seq(nino),
+      "version" -> Seq(version),
+      "systemId" -> Seq(systemId),
+      "correlationId" -> Seq(correlationId.toString)
     )
 
     val queryString = s"nino=$nino&version=$version&systemId=$systemId&correlationId=$correlationId"
@@ -176,7 +176,7 @@ class HelpToSaveControllerSpec extends AuthSupport {
     }
   }
 
-  def commonBehaviour(doCall: () ⇒ Action[AnyContent], mockNSIFailure: () ⇒ Unit, nsiPayload: NSIPayload): Unit = {
+  def commonBehaviour(doCall: () => Action[AnyContent], mockNSIFailure: () => Unit, nsiPayload: NSIPayload): Unit = {
 
     "return an InternalServerError status when the call to NSI returns an error" in {
       inSequence {

--- a/test/uk/gov/hmrc/helptosaveproxy/controllers/UCClaimantCheckControllerSpec.scala
+++ b/test/uk/gov/hmrc/helptosaveproxy/controllers/UCClaimantCheckControllerSpec.scala
@@ -21,7 +21,7 @@ import java.util.UUID
 import cats.data.EitherT
 import cats.instances.future._
 import play.api.libs.json.Json
-import play.api.mvc.{Result ⇒ PlayResult}
+import play.api.mvc.{Result => PlayResult}
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
 import uk.gov.hmrc.helptosaveproxy.util.AuthSupport

--- a/test/uk/gov/hmrc/helptosaveproxy/health/DWPConnectionHealthCheckSpec.scala
+++ b/test/uk/gov/hmrc/helptosaveproxy/health/DWPConnectionHealthCheckSpec.scala
@@ -54,7 +54,7 @@ class DWPConnectionHealthCheckSpec extends ActorTestSupport("DWPConnectionHealth
 
       "call the DWPConnector to do the test and reply back with a negative result " +
         "if the DWPConnector returns a failure" in {
-        def test(mockActions: ⇒ Unit): Unit = {
+        def test(mockActions: => Unit): Unit = {
           mockActions
 
           val runner = newRunner()

--- a/test/uk/gov/hmrc/helptosaveproxy/health/HealthTestSpec.scala
+++ b/test/uk/gov/hmrc/helptosaveproxy/health/HealthTestSpec.scala
@@ -45,7 +45,7 @@ class HealthTestSpec extends ActorTestSupport("HealthTestSpec") with BeforeAndAf
 
   val testName = "test"
 
-  val (runnerName1, runnerName2) = "runner1" → "runner2"
+  val (runnerName1, runnerName2) = "runner1" -> "runner2"
 
   val minimumTimeBetweenTests: FiniteDuration = 1.minute
 
@@ -106,12 +106,12 @@ class HealthTestSpec extends ActorTestSupport("HealthTestSpec") with BeforeAndAf
         ),
         time.scheduler,
         metrics,
-        () ⇒ pagerDutyListener.ref ! PagerDutyAlert,
+        () => pagerDutyListener.ref ! PagerDutyAlert,
         Props(new ProxyActor(runnerListener.ref, runnerName1)),
         Props(new ProxyActor(runnerListener.ref, runnerName2))
       ))
 
-    ref → time
+    ref -> time
   }
 
   val (healthCheck: ActorRef, time: VirtualTime) = newHealthCheck()
@@ -125,7 +125,7 @@ class HealthTestSpec extends ActorTestSupport("HealthTestSpec") with BeforeAndAf
 
     runnerListener.expectMsg(PerformHealthCheck)
     runnerListener.reply(
-      result.fold[HealthCheckResult](e ⇒ HealthCheckResult.Failure(e, 0L), _ ⇒ HealthCheckResult.Success("", 0L))
+      result.fold[HealthCheckResult](e => HealthCheckResult.Failure(e, 0L), _ => HealthCheckResult.Success("", 0L))
     )
 
     runnerListener.expectTerminated(created.ref)
@@ -168,7 +168,7 @@ class HealthTestSpec extends ActorTestSupport("HealthTestSpec") with BeforeAndAf
         "create a child runner with the next set of props when " +
           "the configured number of successful tests between updates have " +
           "been performed" in {
-          (2 until numberOfTestsBetweenUpdates).foreach { _ ⇒
+          (2 until numberOfTestsBetweenUpdates).foreach { _ =>
             time.advance(timeBetweenTests)
             mockTest(runnerName1, Right(()))
             metricsListener.expectMsg(0)
@@ -183,7 +183,7 @@ class HealthTestSpec extends ActorTestSupport("HealthTestSpec") with BeforeAndAf
         "create a child runner with the first set of props when " +
           "the configured number of successful tests between updates have " +
           "been performed and all the props given have been used" in {
-          (1 until numberOfTestsBetweenUpdates).foreach { _ ⇒
+          (1 until numberOfTestsBetweenUpdates).foreach { _ =>
             time.advance(timeBetweenTests)
             mockTest(runnerName2, Right(()))
             metricsListener.expectMsg(0)
@@ -271,7 +271,7 @@ class HealthTestSpec extends ActorTestSupport("HealthTestSpec") with BeforeAndAf
       "the configured number of maximum consecutive test failures has been reached" must {
 
         "record the appropriate number of failures and trigger pager duty" in {
-          (1 until maximumConsecutiveFailures).foreach { i ⇒
+          (1 until maximumConsecutiveFailures).foreach { i =>
             time.advance(timeBetweenTests)
             mockTest(runnerName1, Left(""))
             metricsListener.expectMsg(i)
@@ -292,7 +292,7 @@ class HealthTestSpec extends ActorTestSupport("HealthTestSpec") with BeforeAndAf
       "the configured number of test failures between pager duty alerts has been reached" must {
 
         "record the appropriate number of failures and trigger pager duty again" in {
-          (1 until numberOfTestsBetweenAlerts).foreach { i ⇒
+          (1 until numberOfTestsBetweenAlerts).foreach { i =>
             time.advance(timeBetweenTests)
             mockTest(runnerName1, Left(""))
             metricsListener.expectMsg(maximumConsecutiveFailures + i)
@@ -374,7 +374,7 @@ object HealthTestSpec {
     }
 
     override def receive: Receive = {
-      case PerformHealthCheck ⇒ (ref ? PerformHealthCheck) pipeTo sender()
+      case PerformHealthCheck => (ref ? PerformHealthCheck) pipeTo sender()
     }
 
   }

--- a/test/uk/gov/hmrc/helptosaveproxy/health/HealthTestSpec.scala
+++ b/test/uk/gov/hmrc/helptosaveproxy/health/HealthTestSpec.scala
@@ -25,7 +25,6 @@ import com.codahale.metrics._
 import com.kenshoo.play.metrics.Metrics
 import com.miguno.akka.testing.VirtualTime
 import com.typesafe.config.ConfigFactory
-import org.junit.Before
 import org.scalatest.BeforeAndAfter
 import uk.gov.hmrc.helptosaveproxy.connectors.NSIConnector
 import uk.gov.hmrc.helptosaveproxy.health.HealthCheck.PerformHealthCheck

--- a/test/uk/gov/hmrc/helptosaveproxy/health/NSIConnectionHealthCheckRunnerSpec.scala
+++ b/test/uk/gov/hmrc/helptosaveproxy/health/NSIConnectionHealthCheckRunnerSpec.scala
@@ -71,7 +71,7 @@ class NSIConnectionHealthCheckRunnerSpec extends ActorTestSupport("NSIConnection
 
       "call the NSIConnector to do the test and reply back with a negative result " +
         "if the NSIConnector returns a failure" in {
-        def test(mockActions: ⇒ Unit): Unit = {
+        def test(mockActions: => Unit): Unit = {
           mockActions
 
           val runner = newRunner(Payload2)

--- a/test/uk/gov/hmrc/helptosaveproxy/models/NSIPayloadSpec.scala
+++ b/test/uk/gov/hmrc/helptosaveproxy/models/NSIPayloadSpec.scala
@@ -44,11 +44,11 @@ class NSIPayloadSpec extends AnyWordSpec with Matchers { // scalastyle:off magic
         (json1 \ "dateOfBirth").get shouldBe JsString("12340506")
 
         // check the read will fail if the date is in the wrong format
-        val json2 = json1.as[JsObject] ++ Json.obj("dateOfBirth" → JsString("not a date"))
+        val json2 = json1.as[JsObject] ++ Json.obj("dateOfBirth" -> JsString("not a date"))
         Json.fromJson[NSIPayload](json2).isError shouldBe true
 
         // check that read will fail if the date is not a string
-        val json3 = json1.as[JsObject] ++ Json.obj("dateOfBirth" → JsNumber(0))
+        val json3 = json1.as[JsObject] ++ Json.obj("dateOfBirth" -> JsNumber(0))
         Json.fromJson[NSIPayload](json3).isError shouldBe true
       }
     }
@@ -173,7 +173,7 @@ class NSIPayloadSpec extends AnyWordSpec with Matchers { // scalastyle:off magic
       }
 
       "filters out country codes equal to the string 'other'" in {
-        Set("other", "OTHER", "Other").foreach { other ⇒
+        Set("other", "OTHER", "Other").foreach { other =>
           val result = performReads(
             validNSIPayload.copy(contactDetails = validNSIPayload.contactDetails.copy(countryCode = Some(other))))
           result.contactDetails.countryCode shouldBe None
@@ -181,7 +181,7 @@ class NSIPayloadSpec extends AnyWordSpec with Matchers { // scalastyle:off magic
       }
 
       "remove hyphened suffix from country codes" in {
-        Set("GB-ENG", "GB-NIR", "GB-SCT", "GB-WLS").foreach { gb ⇒
+        Set("GB-ENG", "GB-NIR", "GB-SCT", "GB-WLS").foreach { gb =>
           val result = performReads(
             validNSIPayload.copy(contactDetails = validNSIPayload.contactDetails.copy(countryCode = Some(gb))))
           result.contactDetails.countryCode shouldBe Some("GB")
@@ -194,7 +194,7 @@ class NSIPayloadSpec extends AnyWordSpec with Matchers { // scalastyle:off magic
           "123456",
           "12 34 56",
           "12_34_56"
-        ).foreach { sortCode ⇒
+        ).foreach { sortCode =>
           withClue(s"For sort code $sortCode: ") {
             val json: JsValue =
               Json.toJson(validNSIPayload.copy(nbaDetails = Some(validBankDetails.copy(sortCode = sortCode))))

--- a/test/uk/gov/hmrc/helptosaveproxy/services/JSONSchemaValidationServiceImplSpec.scala
+++ b/test/uk/gov/hmrc/helptosaveproxy/services/JSONSchemaValidationServiceImplSpec.scala
@@ -34,7 +34,7 @@ class JSONSchemaValidationServiceImplSpec extends TestSupport {
   implicit class JsValueOps(val jsValue: JsValue) {
 
     def replace[A <: JsValue](field: String, newValue: A): JsValue =
-      jsValue.as[JsObject] ++ Json.obj(field → newValue)
+      jsValue.as[JsObject] ++ Json.obj(field -> newValue)
 
     def replaceInner[A <: JsValue](field: String, innerField: String, newValue: A): JsValue = {
       val inner = (jsValue \ field).getOrElse(sys.error(s"Could not find field $field"))

--- a/test/uk/gov/hmrc/helptosaveproxy/testutil/MockPagerDuty.scala
+++ b/test/uk/gov/hmrc/helptosaveproxy/testutil/MockPagerDuty.scala
@@ -19,7 +19,7 @@ package uk.gov.hmrc.helptosaveproxy.testutil
 import org.scalamock.scalatest.MockFactory
 import uk.gov.hmrc.helptosaveproxy.util.PagerDutyAlerting
 
-trait MockPagerDuty { this: MockFactory ⇒
+trait MockPagerDuty { this: MockFactory =>
 
   val mockPagerDuty: PagerDutyAlerting = mock[PagerDutyAlerting]
 

--- a/test/uk/gov/hmrc/helptosaveproxy/testutil/TestData.scala
+++ b/test/uk/gov/hmrc/helptosaveproxy/testutil/TestData.scala
@@ -34,8 +34,8 @@ object TestData {
     implicit def providerLocalDate(s: String): GenProvider[LocalDate] =
       instance({
         s.toLowerCase match {
-          case "dateofbirth" | "dob" | "birthdate" ⇒ Gen.date(LocalDate.of(1900, 1, 1), LocalDate.now())
-          case _ ⇒ Gen.date
+          case "dateofbirth" | "dob" | "birthdate" => Gen.date(LocalDate.of(1900, 1, 1), LocalDate.now())
+          case _ => Gen.date
         }
       })
 
@@ -47,7 +47,7 @@ object TestData {
       * Valid user details which will pass NSI validation checks
       */
     val (nsiValidContactDetails, validNSIPayload, validBankDetails) = {
-      val (forename, surname) = "Tyrion" → "Lannister"
+      val (forename, surname) = "Tyrion" -> "Lannister"
       val dateOfBirth = LocalDate.ofEpochDay(0L)
       val addressLine1 = "Casterly Rock"
       val addressLine2 = "The Westerlands"

--- a/test/uk/gov/hmrc/helptosaveproxy/testutil/testutil.scala
+++ b/test/uk/gov/hmrc/helptosaveproxy/testutil/testutil.scala
@@ -18,7 +18,7 @@ package uk.gov.hmrc.helptosaveproxy
 
 import org.scalacheck.Gen
 
-import scala.reflect.{ClassTag, _}
+import scala.reflect._
 
 package object testutil {
 

--- a/test/uk/gov/hmrc/helptosaveproxy/util/LockSpec.scala
+++ b/test/uk/gov/hmrc/helptosaveproxy/util/LockSpec.scala
@@ -17,11 +17,10 @@
 package uk.gov.hmrc.helptosaveproxy.util
 
 import akka.actor.{ActorRef, Props}
-import com.google.inject.Inject
 import com.miguno.akka.testing.VirtualTime
 import uk.gov.hmrc.helptosaveproxy.health.ActorTestSupport
 import uk.gov.hmrc.helptosaveproxy.util.lock.Lock
-import uk.gov.hmrc.mongo.lock.{LockRepository, MongoLockRepository, TimePeriodLockService}
+import uk.gov.hmrc.mongo.lock.{LockRepository, TimePeriodLockService}
 
 import scala.concurrent.duration._
 import scala.concurrent.{ExecutionContext, Future}

--- a/test/uk/gov/hmrc/helptosaveproxy/util/LockSpec.scala
+++ b/test/uk/gov/hmrc/helptosaveproxy/util/LockSpec.scala
@@ -61,8 +61,8 @@ class LockSpec extends ActorTestSupport("LockSpec") {
           internalLock,
           time.scheduler,
           State(0),
-          s ⇒ sendToSelf(State(s.i + 1)),
-          s ⇒ sendToSelf(State(s.i - 1)), { f ⇒
+          s => sendToSelf(State(s.i + 1)),
+          s => sendToSelf(State(s.i - 1)), { f =>
             sendToSelf(StopHook(f)); ()
           }
         )
@@ -74,11 +74,11 @@ class LockSpec extends ActorTestSupport("LockSpec") {
     (internalLock
       .withRenewedLock(_: Future[Unit])(_: ExecutionContext))
       .expects(*, *)
-      .returning(result.fold(e ⇒ Future.failed(new Exception(e)), Future.successful))
+      .returning(result.fold(e => Future.failed(new Exception(e)), Future.successful))
 
   "The Lock" must {
 
-    def startNewLock(mockActions: ⇒ Unit): (ActorRef, VirtualTime, StopHook) = {
+    def startNewLock(mockActions: => Unit): (ActorRef, VirtualTime, StopHook) = {
       mockActions
 
       // start the actor
@@ -160,6 +160,6 @@ object LockSpec {
 
   case class State(i: Int)
 
-  case class StopHook(f: () ⇒ Future[Unit])
+  case class StopHook(f: () => Future[Unit])
 
 }


### PR DESCRIPTION
Fixes the lock problem, duration had been coded a million times too short.

Dependency upgrades where practical, there is a problem around latest versions of Scala 2.12 and latest scalatest 2.0.x

Removed warnings

Improved configurability of DWP endpoints to aid DLS-5837 and avoid interdependency