### PR TITLE
DLS-12598 | Fix DWP connector to use custom wsclient via HttpClientV2 impl

### DIFF
--- a/app/uk.gov.hmrc.helptosaveproxy/connectors/DWPConnector.scala
+++ b/app/uk.gov.hmrc.helptosaveproxy/connectors/DWPConnector.scala
@@ -21,12 +21,12 @@ import com.codahale.metrics.Timer
 import com.google.inject.ImplementedBy
 import play.api.http.Status
 import uk.gov.hmrc.helptosaveproxy.config.AppConfig
+import uk.gov.hmrc.helptosaveproxy.http.DwpHttpClientV2
 import uk.gov.hmrc.helptosaveproxy.metrics.Metrics
 import uk.gov.hmrc.helptosaveproxy.metrics.Metrics.*
 import uk.gov.hmrc.helptosaveproxy.util.Logging.*
 import uk.gov.hmrc.helptosaveproxy.util.{LogMessageTransformer, Logging, PagerDutyAlerting}
 import uk.gov.hmrc.http.HttpReads.Implicits.*
-import uk.gov.hmrc.http.client.HttpClientV2
 import uk.gov.hmrc.http.{HeaderCarrier, HttpResponse, StringContextOps}
 
 import java.util.UUID
@@ -44,7 +44,7 @@ trait DWPConnector {
 class DWPConnectorImpl @Inject()(
   metrics: Metrics,
   pagerDutyAlerting: PagerDutyAlerting,
-  http: HttpClientV2)(implicit transformer: LogMessageTransformer, appConfig: AppConfig)
+  http: DwpHttpClientV2)(implicit transformer: LogMessageTransformer, appConfig: AppConfig)
     extends DWPConnector with Logging {
   def ucClaimantCheck(nino: String, transactionId: UUID, threshold: Double)(
     implicit hc: HeaderCarrier,

--- a/app/uk.gov.hmrc.helptosaveproxy/http/DwpHttpClientV2.scala
+++ b/app/uk.gov.hmrc.helptosaveproxy/http/DwpHttpClientV2.scala
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.helptosaveproxy.http
+
+import com.google.inject.ImplementedBy
+import org.apache.pekko.actor.ActorSystem
+import play.api.Configuration
+import uk.gov.hmrc.helptosaveproxy.config.DwpWsClient
+import uk.gov.hmrc.http.client.{HttpClientV2, HttpClientV2Impl}
+import uk.gov.hmrc.http.hooks.HttpHook
+
+import javax.inject.{Inject, Singleton}
+
+@ImplementedBy(classOf[DwpHttpClientV2Impl])
+trait DwpHttpClientV2 extends HttpClientV2
+
+@Singleton
+class DwpHttpClientV2Impl @Inject()(
+  dwpWsClient: DwpWsClient,
+  actorSystem: ActorSystem,
+  configuration: Configuration,
+  httpHooks: Seq[HttpHook])
+    extends HttpClientV2Impl(dwpWsClient, actorSystem, configuration, httpHooks) with DwpHttpClientV2

--- a/app/uk.gov.hmrc.helptosaveproxy/http/HttpHooksModule.scala
+++ b/app/uk.gov.hmrc.helptosaveproxy/http/HttpHooksModule.scala
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.helptosaveproxy.http
+
+import com.google.inject.{AbstractModule, TypeLiteral}
+import uk.gov.hmrc.http.hooks.HttpHook
+
+class HttpHooksModule extends AbstractModule {
+  override def configure(): Unit =
+    bind(new TypeLiteral[Seq[HttpHook]]() {}).toInstance(Seq.empty[HttpHook])
+}

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -31,6 +31,7 @@ play.modules.enabled += "uk.gov.hmrc.play.bootstrap.HttpClientV2Module"
 
 play.modules.disabled += "play.api.libs.ws.ahc.AhcWSModule"
 play.modules.enabled += "uk.gov.hmrc.helptosaveproxy.http.NewWSModule"
+play.modules.enabled += "uk.gov.hmrc.helptosaveproxy.http.HttpHooksModule"
 
 play.filters.disabled += play.filters.csrf.CSRFFilter
 play.filters.disabled += play.filters.hosts.AllowedHostsFilter

--- a/test/uk/gov/hmrc/helptosaveproxy/connectors/DWPConnectorSpec.scala
+++ b/test/uk/gov/hmrc/helptosaveproxy/connectors/DWPConnectorSpec.scala
@@ -59,7 +59,10 @@ class DWPConnectorSpec
     )
   )
 
-  override def fakeApplication(): Application = new GuiceApplicationBuilder().configure(config).build()
+  override def fakeApplication(): Application =
+    new GuiceApplicationBuilder()
+      .configure(config)
+      .build()
 
   val connector: DWPConnector = app.injector.instanceOf[DWPConnectorImpl]
   implicit val hc: HeaderCarrier = HeaderCarrier()


### PR DESCRIPTION
- DWP connector to use a custom DwpHttpClientV2 backed by the DWP WS client, ensuring the connector goes through the intended WS stack for certs.
- Module to bind empty HttpHook sequences